### PR TITLE
Remove configparser non existant 'default' value

### DIFF
--- a/restricted_pkg/base.py
+++ b/restricted_pkg/base.py
@@ -177,7 +177,7 @@ class PyPIConfig(object):
         config = configparser.ConfigParser()
         config.read(self.path)
         if config.has_section('distutils'):
-            server_names = config.get('distutils', 'index-servers', '')
+            server_names = config.get('distutils', 'index-servers')
             servers = [name.strip() for name in server_names.split('\n')]
             servers = [server for server in servers if server]
 


### PR DESCRIPTION
There is no default argument in the "get" method in configparser

http://docs.python.org/2/library/configparser.html#ConfigParser.ConfigParser.get
http://docs.python.org/3.3/library/configparser.html#configparser.ConfigParser.get
