### PR TITLE
Add support for custom HTTP headers on upload

### DIFF
--- a/restricted_pkg/commands.py
+++ b/restricted_pkg/commands.py
@@ -187,6 +187,173 @@ class upload(base_upload):
 
         base_upload.finalize_options(self)
 
+    # Since we want to be able to add custom headers, we need to copy the entire upload_file(..)
+    # method from distutils.command.upload. This method prepares and creates the urllib2.Request
+    # object which we will update to include the custom headers (typically for authentication
+    # purposes) specified in the package's setup.py ("setup(...)") metadata.
+    def upload_file_extended(self, command, pyversion, filename):
+        # copy imports from distutils.command.upload
+        import socket
+        import platform
+        from urllib2 import urlopen, Request, HTTPError
+        from base64 import standard_b64encode
+        import urlparse
+        import cStringIO as StringIO
+        from hashlib import md5
+        from distutils.errors import DistutilsError
+        from distutils.spawn import spawn
+        from distutils import log
+
+        encode_content_base64 = True
+
+        # Makes sure the repository URL is compliant
+        schema, netloc, url, params, query, fragments = \
+            urlparse.urlparse(self.repository)
+        if params or query or fragments:
+            raise AssertionError("Incompatible url %s" % self.repository)
+
+        if schema not in ('http', 'https'):
+            raise AssertionError("unsupported schema " + schema)
+
+        # Sign if requested
+        if self.sign:
+            gpg_args = ["gpg", "--detach-sign", "-a", filename]
+            if self.identity:
+                gpg_args[2:2] = ["--local-user", self.identity]
+            spawn(gpg_args,
+                  dry_run=self.dry_run)
+
+        # Fill in the data - send all the meta-data in case we need to
+        # register a new release
+        f = open(filename,'rb')
+        try:
+            content = f.read()
+        finally:
+            f.close()
+        if encode_content_base64:
+            content = standard_b64encode(content)
+        meta = self.distribution.metadata
+        data = {
+            # action
+            ':action': 'file_upload',
+            'protcol_version': '1',
+
+            # identify release
+            'name': meta.get_name(),
+            'version': meta.get_version(),
+
+            # file content
+            'content': (os.path.basename(filename),content),
+            'filetype': command,
+            'pyversion': pyversion,
+            'md5_digest': md5(content).hexdigest(),
+
+            # additional meta-data
+            'metadata_version' : '1.0',
+            'summary': meta.get_description(),
+            'home_page': meta.get_url(),
+            'author': meta.get_contact(),
+            'author_email': meta.get_contact_email(),
+            'license': meta.get_licence(),
+            'description': meta.get_long_description(),
+            'keywords': meta.get_keywords(),
+            'platform': meta.get_platforms(),
+            'classifiers': meta.get_classifiers(),
+            'download_url': meta.get_download_url(),
+            # PEP 314
+            'provides': meta.get_provides(),
+            'requires': meta.get_requires(),
+            'obsoletes': meta.get_obsoletes(),
+            }
+        comment = ''
+        if command == 'bdist_rpm':
+            dist, version, id = platform.dist()
+            if dist:
+                comment = 'built for %s %s' % (dist, version)
+        elif command == 'bdist_dumb':
+            comment = 'built for %s' % platform.platform(terse=1)
+        data['comment'] = comment
+
+        if self.sign:
+            data['gpg_signature'] = (os.path.basename(filename) + ".asc",
+                                     open(filename+".asc").read())
+
+        # set up the authentication
+        auth = "Basic " + standard_b64encode(self.username + ":" +
+                                             self.password)
+
+        # Build up the MIME payload for the POST data
+        boundary = '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254'
+        sep_boundary = '\r\n--' + boundary
+        end_boundary = sep_boundary + '--\r\n'
+        body = StringIO.StringIO()
+        for key, value in data.items():
+            # handle multiple entries for the same name
+            if not isinstance(value, list):
+                value = [value]
+            for value in value:
+                if isinstance(value, tuple):
+                    fn = ';filename="%s"' % value[0]
+                    value = value[1]
+                else:
+                    fn = ""
+
+                body.write(sep_boundary)
+                body.write('\r\nContent-Disposition: form-data; name="%s"' % key)
+                body.write(fn)
+                if encode_content_base64 and fn:
+                    body.write('\r\nContent-Transfer-Encoding: base64')
+                body.write("\r\n\r\n")
+                body.write(value)
+                if value and value[-1] == '\r':
+                    body.write('\n')  # write an extra newline (lurve Macs)
+        body.write(end_boundary)
+        body = body.getvalue()
+
+        self.announce("Submitting %s to %s" % (filename, self.repository), log.INFO)
+
+        # build the Request
+        headers = {'Content-type':
+                        'multipart/form-data; boundary=%s' % boundary,
+                   'Content-length': str(len(body)),
+                   'Authorization': auth}
+        # add custom headers, if any
+        if self.distribution.custom_headers:
+            headers.update(self.distribution.custom_headers)
+
+        request = Request(self.repository, data=body,
+                          headers=headers)
+        # send the data
+        try:
+            result = urlopen(request)
+            status = result.getcode()
+            reason = result.msg
+            if self.show_response:
+                msg = '\n'.join(('-' * 75, result.read(), '-' * 75))
+                self.announce(msg, log.INFO)
+        except socket.error, e:
+            self.announce(str(e), log.ERROR)
+            raise
+        except HTTPError, e:
+            status = e.code
+            reason = e.msg
+
+        if status == 200:
+            self.announce('Server response (%s): %s' % (status, reason),
+                          log.INFO)
+        else:
+            msg = 'Upload failed (%s): %s' % (status, reason)
+            self.announce(msg, log.ERROR)
+            raise DistutilsError(msg)
+
+    def upload_file(self, command, pyversion, filename):
+        if not self.distribution.custom_headers:
+            # use base version
+            return base_upload.upload_file(command, pyversion, filename)
+        else:
+            # use extended version that supports custom headers
+            return self.upload_file_extended(command, pyversion, filename)
+
 
 class upload_docs(base_upload_docs):
     """Overridden upload_docs command restricting upload to the private repo."""

--- a/restricted_pkg/validators.py
+++ b/restricted_pkg/validators.py
@@ -12,3 +12,7 @@ from distutils.errors import DistutilsSetupError
 def validate_private_repo(distribution, attr, value):
     if not value:
         raise DistutilsSetupError("The %s value cannot be empty." % attr)
+
+
+def validate_custom_headers(distribution, attr, value):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     entry_points={
         'distutils.setup_keywords': [
             'private_repository = restricted_pkg.validators:validate_private_repo',
+            'custom_headers = restricted_pkg.validators:validate_custom_headers'
         ],
     },
 )


### PR DESCRIPTION
First of all, @rbarrois thanks for maintaining this very useful project! :)

This PR adds support for custom HTTP headers when running `pip upload` against a private repo. Some private pypi repositories, for example JFrog Artifactory, require an API Key token to be passed as HTTP header. This can now be achieved via the `custom_headers={...}` configuration passed in to the `setup(...)` method.

Backwards compatibility is fully preserved - if the `custom_headers` parameter is not specified, the base version of `upload_file` is used instead.
